### PR TITLE
Improve docs and require Julia 1.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Jaan Tollander de Balsch <jaan@hey.com>"]
 version = "0.1.0"
 
 [compat]
-julia = "^1.3"
+julia = "1.11"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ You can cite the `CellLists.jl` repository and code by navigating to the [**DOI*
 
 
 ## Installation
-You can install `CellLists.jl` with the Julia package manager.
+CellLists.jl requires Julia 1.11 or newer, so make sure you are using the
+latest stable release of Julia. You can install the package with the Julia
+package manager.
 
 ```
 pkg> add CellLists
@@ -25,6 +27,13 @@ Alternatively, you can install `CellLists.jl` directly from the GitHub repositor
 
 ```
 pkg> add https://github.com/jaantollander/CellLists.jl
+```
+
+A minimal runnable example is provided in `examples/basic_example.jl` and can be
+executed with
+
+```
+$ julia examples/basic_example.jl
 ```
 
 
@@ -84,3 +93,17 @@ near_neighbors(c, p, r, Val(:threads))
 
 ## Benchmarks
 You can find the benchmarking code from the [**CellListsBenchmarks.jl**](https://github.com/jaantollander/CellListsBenchmarks.jl) repository and scripts for running the benchmarks and plotting in the [**cell-lists-benchmarks**](https://github.com/jaantollander/cell-lists-benchmarks) repository.
+
+## Testing
+The test suite can be run with the Julia package manager:
+
+```
+julia --project -e 'using Pkg; Pkg.test()'
+```
+
+## Building Documentation
+To build the documentation locally run
+
+```
+julia --project=docs docs/make.jl
+```

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,8 @@ using CellLists
 makedocs(
     sitename = "CellLists",
     format = Documenter.HTML(),
-    modules = [CellLists]
+    modules = [CellLists],
+    strict = false,
 )
 
 # Documenter can also automatically deploy documentation to gh-pages.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,13 +4,19 @@ Documentation for CellLists.jl
 ## Serial
 ```@docs
 CellList
-CellList(::Array{T, 2}, ::T; ::Int) where T <: AbstractFloat
-near_neighbors(::CellList, ::Array{T, 2}, ::T) where T <: AbstractFloat
+near_neighbors
+```
+
+## Helper functions
+```@docs
+neighbors
+distance_condition
+brute_force!
 ```
 
 ## Multithreading
 ```@docs
-merge(::CellList{d}, ::CellList{d}) where d
+merge
 CellList(::Array{T, 2}, ::T, ::Val{:threads}) where T <: AbstractFloat
 near_neighbors(::CellList{d}, ::Array{T, 2}, ::T, ::Val{:threads}) where d where T <: AbstractFloat
 ```

--- a/examples/basic_example.jl
+++ b/examples/basic_example.jl
@@ -1,0 +1,7 @@
+using CellLists
+
+n, d, r = 100, 2, 0.1
+points = rand(n, d)
+cl = CellList(points, r)
+indices = near_neighbors(cl, points, r)
+println(indices)

--- a/src/serial.jl
+++ b/src/serial.jl
@@ -29,16 +29,33 @@ function CellList(p::Array{T, 2}, r::T; offset::Int=0) where T <: AbstractFloat
     CellList{d}(data)
 end
 
-"""Compute offsets to neighboring cells in `d` dimensions."""
+"""
+    neighbors(d::Int)
+
+Compute offsets to all neighboring cells in `d` dimensions. The returned vector
+excludes the zero offset so that each pair of cells is visited only once.
+"""
 @inline function neighbors(d::Int)
     n = CartesianIndices((fill(-1:1, d)...,))
     return n[1:fld(length(n), 2)]
 end
 
+"""
+    distance_condition(p1, p2, r)
+
+Return `true` if the Euclidean distance between vectors `p1` and `p2` is less
+than or equal to `r`.
+"""
 @inline function distance_condition(p1::Vector{T}, p2::Vector{T}, r::T) where T <: AbstractFloat
     sum(@. (p1 - p2)^2) ≤ r^2
 end
 
+"""
+    brute_force!(pairs, is, points, r)
+
+Check all pairs of indices in `is` and push those within distance `r` to
+`pairs`. This helper is used internally by [`near_neighbors`](@ref).
+"""
 @inline function brute_force!(ps::Vector{Tuple{Int, Int}}, is::Vector{Int}, p::Array{T, 2}, r::T) where T <: AbstractFloat
     for (k, i) in enumerate(is[1:(end-1)])
         for j in is[(k+1):end]
@@ -49,6 +66,12 @@ end
     end
 end
 
+"""
+    brute_force!(pairs, is, js, points, r)
+
+Compare each index in `is` with every index in `js` and push valid pairs to
+`pairs`.
+"""
 @inline function brute_force!(ps::Vector{Tuple{Int, Int}}, is::Vector{Int}, js::Vector{Int}, p::Array{T, 2}, r::T) where T <: AbstractFloat
     for i in is
         for j in js

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,7 +85,7 @@ end
 
 const rng = MersenneTwister(894)
 const ns = [0, 1, 2, 10, 100]
-const ds = [1, 2, 3]
+const ds = [1, 2, 3, 5]
 const rs = [0.1, 0.2, 0.3, 0.5, 1.0, 2.0]
 test_cell_lists_serial(rng, ns, ds, rs, 20)
 test_merge(rng, ns, ds, rs)
@@ -93,3 +93,5 @@ test_cell_list_constructor_threads(rng, ns, ds, rs)
 test_near_neighbors_threads(rng, ns, ds, rs, 20)
 test_near_neighbors_threads_large(rng, 20000, 2, 0.01)
 test_near_neighbors_threads_large(rng, 30000, 3, 0.01)
+
+@test_throws AssertionError CellList(rand(rng, 5, 2), 0.0)


### PR DESCRIPTION
## Summary
- require Julia v1.11 or later in Project.toml
- mention new Julia requirement in the README
- relax Documenter strictness and document helper functions

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'`
- `julia --project=docs docs/make.jl` *(fails: Package Documenter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e99dec40083239c2cf492a587c472